### PR TITLE
Remove deprecated flags passed to bee

### DIFF
--- a/modules.d/46bzz/bee.yaml
+++ b/modules.d/46bzz/bee.yaml
@@ -2,8 +2,6 @@
 
 api-addr: :1633
 data-dir: /var/lib/bee
-debug-api-addr: 127.0.0.1:1635
-debug-api-enable: true
 password-file: /var/lib/bee/password
 chequebook-enable: false
 swap-enable: false # otherwise we deploy a new chequebook on every invocation!


### PR DESCRIPTION
This pull request changes...

## Changes

Remove (now deprecated) flags `debug-api-addr` and `debug-api-enable` from bee.yaml for bee service started by this dracut module.

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
